### PR TITLE
_layouts: remove sharing via Google+ option

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,7 +82,6 @@
         <li><a href="http://twitter.com/HackerEarth" target="_blank"><i class="fa fa-twitter-square fa-lg social-logo"></a></i></li>
         <li><a href="http://facebook.com/HackerEarth" target="_blank"><i class="fa fa-facebook-square fa-lg social-logo"></a></i></li>
         <li><a href="http://www.linkedin.com/company/hackerearth" target="_blank"><i class="fa fa-linkedin-square fa-lg social-logo"></a></i></li>
-        <li><a href="https://plus.google.com/+Hackerearth" target="_blank"><i class="fa fa-google-plus-square fa-lg social-logo"></a></i></li>
       </ul>
         </div>
       </div>


### PR DESCRIPTION
Removed Google+ sharing option from _layouts html page